### PR TITLE
Frontend pvc configuration

### DIFF
--- a/klustair/templates/frontend-pvc.yaml
+++ b/klustair/templates/frontend-pvc.yaml
@@ -5,8 +5,9 @@ metadata:
   labels:
 {{ include "klustair.labels" . | indent 4 }}
 spec:
+  storageClassName: {{ .Values.klustairfrontend.pvc.storageClassName }}
   accessModes:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 1Gi
+      storage: {{ .Values.klustairfrontend.pvc.size }}

--- a/klustair/values.yaml
+++ b/klustair/values.yaml
@@ -48,6 +48,9 @@ klustairfrontend:
       timeout: 5
       ssl: false
       tls: false
+    pvc:
+      storageClassName: "my-storage-class"
+      size: 1Gi
 
 klustair:
   kubeconfig: ""

--- a/klustair/values.yaml
+++ b/klustair/values.yaml
@@ -49,7 +49,7 @@ klustairfrontend:
       ssl: false
       tls: false
     pvc:
-      storageClassName: "my-storage-class"
+      storageClassName: ""
       size: 1Gi
 
 klustair:


### PR DESCRIPTION
If the cluster does not have a default storageClass configured, this manifest was failing to create the frontend pvc.
This little change makes it configurable.