### PR TITLE
fix ingress API for k8s > 1.22.

### DIFF
--- a/klustair/templates/frontend-ingress.yaml
+++ b/klustair/templates/frontend-ingress.yaml
@@ -2,7 +2,7 @@
 {{- $fullName := include "klustair.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
 {{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 {{- else -}}
 apiVersion: extensions/v1beta1
 {{- end }}


### PR DESCRIPTION
fix ingress API for k8s > 1.22. 
Current value is deprecated
https://kubernetes.io/docs/reference/using-api/deprecation-guide/

Ingress

The extensions/v1beta1 and networking.k8s.io/v1beta1 API versions of Ingress is no longer served as of v1.22.

    Migrate manifests and API clients to use the networking.k8s.io/v1 API version, available since v1.19.
    All existing persisted objects are accessible via the new API
    Notable changes:
        spec.backend is renamed to spec.defaultBackend
        The backend serviceName field is renamed to service.name
        Numeric backend servicePort fields are renamed to service.port.number
        String backend servicePort fields are renamed to service.port.name
        pathType is now required for each specified path. Options are Prefix, Exact, and ImplementationSpecific. To match the undefined v1beta1 behavior, use ImplementationSpecific